### PR TITLE
Update paths in Google Cloud Run workflow

### DIFF
--- a/.github/workflows/google-cloudrun-source.yml
+++ b/.github/workflows/google-cloudrun-source.yml
@@ -1,3 +1,5 @@
+# FILEPATH: /c:/Users/Sayu/romodo/fleet-manager/.github/workflows/google-cloudrun-source.yml
+# BEGIN: ed8c6549bwf9
 # This workflow deploys an application to Google Cloud Run when a push is made to the "main" branch
 name: Deploy to Cloud Run from Source
 
@@ -94,7 +96,7 @@ jobs:
     - run: mkdir -p ./artifacts
       # Generate the gh-build-artifact.tar file
     - name: Generate Artifact
-      run: tar -czvf ./artifacts/gh-build-artifact.tar.gz ./fleet-manager/build/
+      run: tar -czvf ./artifacts/gh-build-artifact.tar.gz ./fleet-manager/dist/
 
     # Upload the build artifact for use in the deploy job
     - name: Upload a Build Artifact
@@ -159,3 +161,4 @@ jobs:
     # Print the URL of the deployed application
     - name: Show Output
       run: echo ${{ steps.deploy.outputs.url }}
+# END: ed8c6549bwf9

--- a/.github/workflows/google-cloudrun-source.yml
+++ b/.github/workflows/google-cloudrun-source.yml
@@ -46,8 +46,8 @@ jobs:
     - name: Setup Node.js environment
       uses: actions/setup-node@v4.0.2
       with:
-        node-version-file: ./romodo-fleet-manager/package.json
-        cache-dependency-path: ./romodo-fleet-manager/package-lock.json
+        node-version-file: ./fleet-manager/package.json
+        cache-dependency-path: ./fleet-manager/package-lock.json
         check-latest: true
 
     # Install the latest version of npm
@@ -83,18 +83,18 @@ jobs:
       # Build and push the Docker image to Google Container Registry
     - name: Build and Push Docker image
       run: |
-        pack build gcr.io/${{ env.PROJECT_ID }}/${{ env.SERVICE }}:latest --path ./romodo-fleet-manager/ --builder heroku/buildpacks:20
+        pack build gcr.io/${{ env.PROJECT_ID }}/${{ env.SERVICE }}:latest --path ./fleet-manager/ --builder heroku/buildpacks:20
         docker push gcr.io/${{ env.PROJECT_ID }}/${{ env.SERVICE }}:latest
 
       # Build the Node.js app
     - run: npm run build
-      working-directory: ./romodo-fleet-manager
+      working-directory: ./fleet-manager
 
     # Create a directory for build artifacts
     - run: mkdir -p ./artifacts
       # Generate the gh-build-artifact.tar file
     - name: Generate Artifact
-      run: tar -czvf ./artifacts/gh-build-artifact.tar.gz ./romodo-fleet-manager/build/
+      run: tar -czvf ./artifacts/gh-build-artifact.tar.gz ./fleet-manager/build/
 
     # Upload the build artifact for use in the deploy job
     - name: Upload a Build Artifact


### PR DESCRIPTION
This pull request updates the paths in the Google Cloud Run workflow to reflect the correct file locations. The paths for the node-version-file and cache-dependency-path have been updated to point to the correct directories in the "fleet-manager" folder. Additionally, the working-directory for the "npm run build" command has been updated to the "fleet-manager" directory. Finally, the artifact generation command has been updated to use the correct build directory in the "fleet-manager" folder.