### PR TITLE
Update Docker configuration for Google Cloud Run

### DIFF
--- a/.github/workflows/google-cloudrun-source.yml
+++ b/.github/workflows/google-cloudrun-source.yml
@@ -141,7 +141,7 @@ jobs:
 
     # Deploy the application to Google Cloud Run
     - name: Configure Docker on gcloud
-      run: gcloud auth configure-docker gcr.io
+      run: gcloud auth configure-docker asia-northeast2-docker.pkg.dev
     - name: Deploy to Cloud Run
       id: deploy
       uses: google-github-actions/deploy-cloudrun@v2.2.0


### PR DESCRIPTION
This pull request updates the Docker configuration for Google Cloud Run. The `gcloud auth configure-docker` command is modified to use the `asia-northeast2-docker.pkg.dev` registry instead of `gcr.io`. This ensures that the application is deployed to the correct registry.