### PR TITLE
Remove npmrc and CNAME files

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-@romodo:registry=https://asia-east1-npm.pkg.dev/romodo-fleets/romodo-frontend-npm/
-//asia-east1-npm.pkg.dev/romodo-fleets/romodo-frontend-npm/:always-auth=true
-//asia-east1-npm.pkg.dev/romodo-fleets/romodo-frontend-npm/:_authToken="ya29.a0AfB_byD2AN43i8-tuh7hDh8hfiNmanyul77r0mF8H7YdeI26QjvS-S2rrV_0bwlnVwbmWBtxyf2i_APEPJJ9vfOGvfh_Zl2ttrBQvbUSPS1bz6n-Ks0exPQn2IKfc4w1Qw_RS9Wiu1Gd9aI_ZTwBkEZGRv7rn_195N4caCgYKAegSARMSFQHGX2Mip9EenApuoHfS7VKUGVyNzA0171"

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.romodo.live


### PR DESCRIPTION
This PR removes the npmrc and CNAME files from the repository. These files are no longer needed and can be safely deleted.