### PR TITLE
Update Node.js version and repository URL

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Semantic Release
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      run: npx semantic-release --repository-url https://github.com/Romodo-by-BitAlchemy/fleet-manager --force
+      run: npx semantic-release --branches dev --repository-url https://github.com/Romodo-by-BitAlchemy/fleet-manager --force


### PR DESCRIPTION
This pull request updates the Node.js version to 20.11.0 and the repository URL to https://github.com/Romodo-by-BitAlchemy/fleet-manager. It also modifies the semantic-release.yml file to run only on the dev branch instead of the main branch.